### PR TITLE
This just drops the Crystal version requirement to be the same as the SecTester

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: ">= 1.2.2"
+crystal: ">= 1.1.1"
 
 license: MIT
 


### PR DESCRIPTION
Hopefully this means less people will need to `--ignore-crystal-version` to use this.