### PR TITLE
Update shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.4.7
   sec_tester:
     github: NeuraLegion/sec-tester-cr
-    version: ~> 1.2.11
+    version: ~> 1.3.0
 
 development_dependencies:
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -13,7 +13,7 @@ dependencies:
     github: luckyframework/habitat
     version: 0.4.7
   sec_tester:
-    github: NeuraLegion/sec_tester
+    github: NeuraLegion/sec-tester-cr
     version: ~> 1.2.11
 
 development_dependencies:


### PR DESCRIPTION
Internal repo rename and re-structure in Bright, getting ready to publish more languages support for the SecTester so we moved the shard to it's own `-cr`