### PR TITLE
Lock Crystal to 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.3.2
+          crystal: 1.4.1
       - name: Install shards
         run: shards install
       - name: Format
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.1.1
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
 
-crystal: ">= 1.1.1"
+crystal: ">= 1.4.0"
 
 license: MIT
 
@@ -19,4 +19,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.4
+    version: ~> 1.0.0


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
