### PR TITLE
Adding an option for a global project ID.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Create a new file in `spec/setup/sec_tester.cr`
 require "lucky_sec_tester"
 
 LuckySecTester.configure do |settings|
+  # This is your API key
   settings.bright_token = ENV["BRIGHT_TOKEN"]
+  # Your project ID which could be environment based, or for app specific
+  # if your company has many projects
+  settings.project_id = LuckyEnv.staging? "staging-id123" : "default-id123"
 end
 ```
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,4 +4,5 @@ require "../src/lucky_sec_tester"
 
 LuckySecTester.configure do |settings|
   settings.bright_token = "test123"
+  settings.project_id = "abc123zyx-default"
 end

--- a/src/lucky_sec_tester.cr
+++ b/src/lucky_sec_tester.cr
@@ -6,7 +6,7 @@ class LuckySecTester
 
   Habitat.create do
     setting bright_token : String, example: "abc.nexp.123secret"
-    setting project_id : String?, example: "ufNQ7Fo4XAFBsuyGpo6YTz"
+    setting project_id : String, example: "ufNQ7Fo4XAFBsuyGpo6YTz"
   end
 
   getter client : SecTester::Test do

--- a/src/lucky_sec_tester.cr
+++ b/src/lucky_sec_tester.cr
@@ -6,6 +6,7 @@ class LuckySecTester
 
   Habitat.create do
     setting bright_token : String, example: "abc.nexp.123secret"
+    setting project_id : String?, example: "ufNQ7Fo4XAFBsuyGpo6YTz"
   end
 
   getter client : SecTester::Test do


### PR DESCRIPTION
Fixes #15

@bararchy should I make this required? I'm trying to think of if you'd ever not have access to the project ID :thinking:  Since we haven't released any versions of this shard yet, I guess it doesn't matter... 