### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.4.1
+          crystal: 1.6.0
       - name: Install shards
         run: shards install
       - name: Format
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.4.0
+          - 1.6.0
           - latest
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -1,11 +1,11 @@
 name: lucky_sec_tester
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
   - Bar Hofesh <bar.hofesh@gmail.com>
 
-crystal: ">= 1.4.0"
+crystal: ">= 1.6.0"
 
 license: MIT
 
@@ -15,9 +15,9 @@ dependencies:
     version: 0.4.7
   sec_tester:
     github: NeuraLegion/sec-tester-cr
-    version: ~> 1.3.4
+    version: ~> 1.4.0
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.1.0
+    version: ~> 1.3.0

--- a/src/lucky_sec_tester.cr
+++ b/src/lucky_sec_tester.cr
@@ -2,7 +2,7 @@ require "habitat"
 require "sec_tester"
 
 class LuckySecTester
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 
   Habitat.create do
     setting bright_token : String, example: "abc.nexp.123secret"


### PR DESCRIPTION
This updates SecTester to the latest 1.4.0, and bumps Crystal to 1.6.0 following Lucky.

Releasing as v0.2.0 since the 0.1.x used the previous sectester 1.3 series.