### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,10 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    container: crystallang/crystal:${{ matrix.crystal_version }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: shards install
-      - name: Fake the nexploit-cli
-        run: echo '#!/usr/bin/env' > /usr/bin/nexploit-cli && chmod +x /usr/bin/nexploit-cli
       - name: Run tests
         run: crystal spec

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky_sec_tester
-version: 0.2.0
+version: 0.3.0
 
 authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>

--- a/src/lucky_sec_tester.cr
+++ b/src/lucky_sec_tester.cr
@@ -2,7 +2,7 @@ require "habitat"
 require "sec_tester"
 
 class LuckySecTester
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 
   Habitat.create do
     setting bright_token : String, example: "abc.nexp.123secret"


### PR DESCRIPTION
This release includes updates for SecTester 1.6. It no longer requires the NodeJS CLI utility.