### PR TITLE
Fixing the version restriction on habitat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: 1.6.0
@@ -39,7 +39,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: shards install
       - name: Run tests

--- a/shard.yml
+++ b/shard.yml
@@ -12,7 +12,7 @@ license: MIT
 dependencies:
   habitat:
     github: luckyframework/habitat
-    version: 0.4.7
+    version: ~> 0.4.8
   sec_tester:
     github: NeuraLegion/sec-tester-cr
     version: ~> 1.6.1


### PR DESCRIPTION
Currently habitat was locked to 0.4.7 which conflicted with other shards that upgraded to 0.4.8. This makes it a little more flexible so it doesn't tank other shards.

Also saw github actions checkout needed an update.