### PR TITLE
Fixing compilation error

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -5,17 +5,17 @@ authors:
   - Jeremy Woertink <jeremywoertink@gmail.com>
   - Bar Hofesh <bar.hofesh@gmail.com>
 
-crystal: ">= 1.6.0"
+crystal: ~> 1.6
 
 license: MIT
 
 dependencies:
   habitat:
     github: luckyframework/habitat
-    version: ~> 0.4.8
+    version: ">= 0.4.7, < 0.5"
   sec_tester:
     github: NeuraLegion/sec-tester-cr
-    version: ~> 1.6.1
+    version: ">= 1.6.1, < 1.7"
 
 development_dependencies:
   ameba:

--- a/src/lucky_sec_tester.cr
+++ b/src/lucky_sec_tester.cr
@@ -13,7 +13,7 @@ class LuckySecTester
     SecTester::Test.new(settings.bright_token)
   end
 
-  delegate :run_check, :cleanup, to: client
+  delegate :run_check, to: client
 
   def build_target
     SecTester::Target.new(Lucky::RouteHelper.settings.base_uri)


### PR DESCRIPTION
When https://github.com/luckyframework/lucky_sec_tester/pull/30 was added in, it updated SecTester to v1.6 which removed the need for a cleanup in https://github.com/NeuraLegion/sec-tester-cr/commit/1cadfb939efc54e2f7d02e44cb7a690b349d4fc2 when the repeater was ported from javascript over to Crystal.

While at it, I also updated the shard versions to match what we're doing in other shards. 