### PR TITLE
Update sec-tester version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ dependencies:
     version: ">= 0.4.7, < 0.5"
   sec_tester:
     github: NeuraLegion/sec-tester-cr
-    version: ">= 1.6.1, < 1.7"
+    version: ">= 1.6.14"
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
Updating to the latest version as we want to make sure it's at minimum 1.6.14 which now supports the new logic of the internal repeater logic.